### PR TITLE
Shuffle button removed, no more prompt since user will go directly to interpretation

### DIFF
--- a/source/card-page.html
+++ b/source/card-page.html
@@ -22,7 +22,6 @@
   </header>
   <main>
     <h1 class="font-with-border">Select three cards</h1>
-    <h1><a href="interpretation.html" title="Go to interp page">CLICK HERE FOR INTERPRETATION PAGE</a></h1>
     <div class="row">
       <div class="card">
         <img id="WheelOfFortune" class="front" src="./assets/FinishedTarotCards/TarotCardBack.png" alt="Front of image 1">

--- a/source/script/shuffle.js
+++ b/source/script/shuffle.js
@@ -129,49 +129,29 @@ window.onload = function() {
         drawCardResult.push(cardData);
 
         if (selectedCards.length === 3) {
-          setTimeout(function() {
-            // Show pop-up
-            //add a time out so the flip get executed before pop up
-            let confirmPopup = confirm('You drew 3 cards. Do you want to go to the interpretation page?');
-            if (confirmPopup) {
-              const keys = ["past", "present", "future"];
+          const keys = ["past", "present", "future"];
 
-              for (let j = 0; j < drawCardResult.length; j++) {
-                localStorage.setItem(keys[j], JSON.stringify(drawCardResult[j]));
-              }
-
-              window.location.href = 'interpretation.html';
-            } else {
-              location.reload();
-            }
-          },500);
+          for (let j = 0; j < drawCardResult.length; j++) {
+            localStorage.setItem(keys[j], JSON.stringify(drawCardResult[j]));
+          }
+          setTimeout(toInterp, 1000);
         }
       } 
     });
   }
-  //the button would shuffle the card deck
-  const shuffleButton = document.getElementById("shuffleButton");
-  if (shuffleButton) {
-    shuffleButton.addEventListener("click", function() {
-      for (var i = 0; i < cards.length; i++) {
-        cards[i].classList.remove("flipped");
-      }
-      shuffle(cardsData);
-      for (var i = 0; i < cards.length; i++) {
-        let front = cards[i].querySelector(".back");
-        front.dataset.name = cardsData[i].name;
-        let redomDirec = Math.floor(Math.random() * 2);
-        if (redomDirec == 0) front.src = cardsData[i].src0;
-        else {
-          front.src = cardsData[i].src1;
-          cardsData[i].direc = 1;
-        }
-      }            
-    });
-  }
 }
 
-// shuffle card function
+/**
+ * Switches to interpretation branch
+ */
+function toInterp() {
+  window.location.href = 'interpretation.html';
+}
+
+/**
+ * Shuffles the cards initially for the user to select from
+ * @param {card[]} array
+ */
 function shuffle(array) {
   let currentIndex = array.length, temporaryValue, randomIndex;
   cardDraw = 0;// when shuffle, reset number of card draw.


### PR DESCRIPTION
Gets rid of the shuffle button. When the user selects 3 cards, they have no choice but to go on to the interpretation. Currently, after the selection of the last card, there is a 1 second wait before the website switches to the interpretation branch, but I feel like we could give some kind of better user feedback, like a transition screen maybe (if its easy) where it's like "determining your fortune..." before going to interpretation