### PR TITLE
Recipe saved

### DIFF
--- a/source/interpPage.js
+++ b/source/interpPage.js
@@ -382,16 +382,12 @@ cards.forEach(card => card.addEventListener("click", flipCard));
 const exitButton = (document.getElementsByClassName("exit"))[0];
 exitButton.addEventListener('click', () => {
   window.location.href = "welcome.html";
-  localStorage.removeItem("interpretation");
-  localStorage.removeItem("recipeIndex");
 })
 
 // New reading button redirects to the card selection page
 const newReadingButton = (document.getElementsByClassName("newReading"))[0];
 newReadingButton.addEventListener('click', () => {
   window.location.href = "card-page.html";
-  localStorage.removeItem("interpretation");
-  localStorage.removeItem("recipeIndex");
 })
 
 // Expand the page for recipe content

--- a/source/interpPage.js
+++ b/source/interpPage.js
@@ -383,6 +383,7 @@ const exitButton = (document.getElementsByClassName("exit"))[0];
 exitButton.addEventListener('click', () => {
   window.location.href = "welcome.html";
   localStorage.removeItem("interpretation");
+  localStorage.removeItem("recipeIndex");
 })
 
 // New reading button redirects to the card selection page
@@ -390,6 +391,7 @@ const newReadingButton = (document.getElementsByClassName("newReading"))[0];
 newReadingButton.addEventListener('click', () => {
   window.location.href = "card-page.html";
   localStorage.removeItem("interpretation");
+  localStorage.removeItem("recipeIndex");
 })
 
 // Expand the page for recipe content

--- a/source/interpPage.js
+++ b/source/interpPage.js
@@ -382,12 +382,14 @@ cards.forEach(card => card.addEventListener("click", flipCard));
 const exitButton = (document.getElementsByClassName("exit"))[0];
 exitButton.addEventListener('click', () => {
   window.location.href = "welcome.html";
+  localStorage.removeItem("interpretation");
 })
 
 // New reading button redirects to the card selection page
 const newReadingButton = (document.getElementsByClassName("newReading"))[0];
 newReadingButton.addEventListener('click', () => {
   window.location.href = "card-page.html";
+  localStorage.removeItem("interpretation");
 })
 
 // Expand the page for recipe content

--- a/source/recipeGenerator.js
+++ b/source/recipeGenerator.js
@@ -49,6 +49,8 @@ function GenerateButtonHandler(button, recipeContainer) {
     const main = document.querySelector(recipeContainer);
     const btn = document.querySelector(button);
     let randomizedIdx = randomNumberGenerator();
+
+    // If index is currently in localStorage, then reuse recipe since must not have been performed
     if (localStorage.getItem("recipeIndex") != null) {
         randomizedIdx = localStorage.getItem("recipeIndex");
     } else {

--- a/source/recipeGenerator.js
+++ b/source/recipeGenerator.js
@@ -48,7 +48,12 @@ function getRecipeFromStorage(index) {
 function GenerateButtonHandler(button, recipeContainer) {
     const main = document.querySelector(recipeContainer);
     const btn = document.querySelector(button);
-    const randomizedIdx = randomNumberGenerator();
+    let randomizedIdx = randomNumberGenerator();
+    if (localStorage.getItem("recipeIndex") != null) {
+        randomizedIdx = localStorage.getItem("recipeIndex");
+    } else {
+        localStorage.setItem("recipeIndex", randomizedIdx);
+    }
     const recipeArticle = document.createElement('custom-recipe');
     btn.addEventListener('click', async () => {
         const recipeData = await getRecipeFromStorage(randomizedIdx);

--- a/source/script/shuffle.js
+++ b/source/script/shuffle.js
@@ -145,6 +145,8 @@ window.onload = function() {
  * Switches to interpretation branch
  */
 function toInterp() {
+  // Ensure that localStorage is only cleared after a new reading has been completed
+  localStorage.clear();
   window.location.href = 'interpretation.html';
 }
 

--- a/source/script/shuffle.js
+++ b/source/script/shuffle.js
@@ -145,8 +145,9 @@ window.onload = function() {
  * Switches to interpretation branch
  */
 function toInterp() {
-  // Ensure that localStorage is only cleared after a new reading has been completed
-  localStorage.clear();
+  // Ensure that the following localStorage items are only cleared after a new reading has been completed
+  localStorage.removeItem("interpretation");
+  localStorage.removeItem("recipeIndex");
   window.location.href = 'interpretation.html';
 }
 


### PR DESCRIPTION
When page refreshes or is revisited before a new reading is made, then reuse previous data. localStorage items for recipeIndex and interpretation are cleared right as a new reading is made to ensure that until that point, the previous page will remain as is.